### PR TITLE
[Feature] Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/100-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/100-documentation.yml
@@ -1,0 +1,21 @@
+name: 📚 Wiki
+description: Report an issue related to https://superioragents.gitbook.io/superior-agents-documents
+title: "[Wiki]: "
+labels: ["wiki"]
+body:
+  - type: textarea
+    attributes:
+      label: 📚 The wiki issue
+      description: >
+        A clear and concise description of what content in https://superioragents.gitbook.io/superior-agents-documents is an issue.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Suggest a potential alternative/fix
+      description: >
+        Tell us how we could improve the wiki in this regard.
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for contributing 🎉~

--- a/.github/ISSUE_TEMPLATE/200-installation.yml
+++ b/.github/ISSUE_TEMPLATE/200-installation.yml
@@ -1,0 +1,99 @@
+name: 🛠️ Installation
+description: Report an issue here when you hit errors during installation.
+title: "[Installation]: "
+labels: ["installation"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting an issue, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/SuperiorAgents/superior-agents/issues?q=is%3Aissue%20state%3Aopen%20sort%3Acreated-desc).
+  - type: dropdown
+    attributes:
+      label: Installation Component
+      description: Which part of the installation process are you having issues with?
+      options:
+        - Prerequisites (Python, Docker, pyenv)
+        - Agent-side installation
+        - ABI files configuration
+        - Python Server-side
+        - Environment Variables
+        - Docker Container
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Your current environment
+      description: |
+        Please provide details about your environment:
+        - OS: [e.g. Ubuntu 20.04, Windows 10, macOS]
+        - Python version: [e.g. 3.12.1]
+        - pyenv version (if applicable): [e.g. 2.3.17]
+        - Docker version (if applicable): [e.g. 24.0.6]
+        - docker-compose version (if applicable): [e.g. 2.20.2]
+      placeholder: |
+        OS: 
+        Python version:
+        pyenv version:
+        Docker version:
+        docker-compose version:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Installation steps attempted
+      description: |
+        Please describe the exact steps you followed during installation.
+      placeholder: |
+        ```sh
+        # List the commands you executed
+        python -m venv agent-venv
+        source agent-venv/bin/activate
+        cd agent
+        pip install -e .
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Error message
+      description: |
+        Please paste the full error message or output that shows the issue.
+      placeholder: |
+        ```
+        Paste the complete terminal output here
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Configuration details
+      description: |
+        If relevant, please share information about your configuration (with sensitive data redacted).
+      placeholder: |
+        .env file structure (remove sensitive values):
+        ```
+        API_DB_BASE_URL=http://localhost:9020
+        # Other config values...
+        ```
+
+        Or any relevant JSON configuration:
+        ```json
+        {
+          "agent_id": "example_agent",
+          "model": "claude"
+        }
+        ```
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context about the problem here.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for contributing 🎉~

--- a/.github/ISSUE_TEMPLATE/300-usage.yml
+++ b/.github/ISSUE_TEMPLATE/300-usage.yml
@@ -1,0 +1,57 @@
+name: 💻 Usage
+description: Raise an issue here if you don't know how to use SuperiorAgents.
+title: "[Usage]: "
+labels: ["usage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting an issue, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/SuperiorAgents/superior-agents/issues?q=is%3Aissue%20state%3Aopen%20sort%3Acreated-desc).
+  - type: textarea
+    attributes:
+      label: Your current environment
+      description: |
+        Please share your environment details including:
+        - OS: [e.g. Windows 10, macOS 12.3, Ubuntu 20.04]
+        - Python version: [e.g. 3.8.10]
+        - SuperiorAgents version: [e.g. 0.1.0]
+        - Installation method: [e.g. pip, source]
+      placeholder: |
+        OS: 
+        Python version:
+        SuperiorAgents version:
+        Installation method:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How would you like to use SuperiorAgents?
+      description: |
+        A detailed description of how you want to use SuperiorAgents.
+      placeholder: |
+        I want to ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What have you tried so far?
+      description: |
+        Please describe what you've already attempted, including any code examples or configurations.
+      placeholder: |
+        I've tried:
+        ```python
+        # Your code here
+        ```
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context or screenshots about your usage question here.
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for contributing 🎉~

--- a/.github/ISSUE_TEMPLATE/400-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/400-bug-report.yml
@@ -1,0 +1,100 @@
+name: 🐛 Bug report
+description: Raise an issue here if you find a bug.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting an issue, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/SuperiorAgents/superior-agents/issues?q=is%3Aissue+sort%3Acreated-desc+).
+  - type: dropdown
+    attributes:
+      label: Component
+      description: Which component of SuperiorAgents are you experiencing the bug in?
+      options:
+        - Agent (Trading)
+        - Agent (Marketing)
+        - Python Server (API/DB)
+        - Docker Container
+        - Notification Scraper
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Your current environment
+      description: |
+        Please share your environment details including:
+        - OS: [e.g. Windows 10, macOS 12.3, Ubuntu 20.04]
+        - Python version: [e.g. 3.12.0]
+        - SuperiorAgents version: [e.g. commit hash or version]
+        - Relevant package versions
+      placeholder: |
+        OS: 
+        Python version:
+        SuperiorAgents version:
+        Package versions:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: 🐛 Describe the bug
+      description: |
+        Please provide a clear and concise description of what the bug is.
+        If relevant, add a minimal example so that we can reproduce the error.
+        For code examples, please use code blocks:
+        ```python
+        # Example code that produces the error
+        ```
+      placeholder: |
+        A clear and concise description of what the bug is.
+
+        Steps to reproduce:
+        1. 
+        2. 
+        3. 
+
+        Error message:
+        ```
+        Paste the full error message and traceback here
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: |
+        Describe what you expected to happen.
+      placeholder: |
+        What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: |
+        If applicable, share relevant configuration details (with sensitive information redacted).
+      placeholder: |
+        Agent configuration:
+        ```json
+        {
+          "agent_id": "example",
+          "model": "claude"
+        }
+        ```
+
+        .env values (WITHOUT sensitive tokens):
+        ```
+        API_DB_BASE_URL=http://localhost:9020
+        ```
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context about the problem here. Screenshots, logs, or other relevant information.
+      placeholder: |
+        Any additional information that might help us diagnose the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/500-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/500-feature-request.yml
@@ -1,0 +1,31 @@
+name: 🚀 Feature request
+description: Submit a proposal/request for a new SuperiorAgents feature
+title: "[Feature]: "
+labels: ["feature"]
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting an issue, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/SuperiorAgents/superior-agents/issues?q=is%3Aissue%20state%3Aopen%20sort%3Acreated-desc).
+  - type: textarea
+    attributes:
+      label: 🚀 The feature, motivation and pitch
+      description: >
+        A clear and concise description of the feature proposal. Please outline the motivation for the proposal. Is your feature request related to a specific problem? e.g., *"I'm working on X and would like Y to be possible"*. If this is related to another GitHub issue, please link here too.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Alternatives
+      description: >
+        A description of any alternative solutions or features you've considered, if any.
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: >
+        Add any other context or screenshots about the feature request.
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for contributing 🎉~

--- a/.github/ISSUE_TEMPLATE/600-misc.yml
+++ b/.github/ISSUE_TEMPLATE/600-misc.yml
@@ -1,0 +1,21 @@
+name: 🎲 Misc/random discussions that do not fit into the above categories.
+description: Submit a discussion as you like.
+title: "[Misc]: "
+labels: ["misc"]
+
+body:
+  - type: markdown
+    attributes:
+      value: >
+        #### Before submitting an issue, please make sure the issue hasn't been already addressed by searching through [the existing and past issues](https://github.com/SuperiorAgents/superior-agents/issues?q=is%3Aissue%20state%3Aopen%20sort%3Acreated-desc).
+  - type: textarea
+    attributes:
+      label: Anything you want to discuss about SuperiorAgents.
+      description: >
+        Anything you want to discuss about SuperiorAgents.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for contributing 🎉!

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Fix for issue #8 

Add standardized GitHub issue templates for:
- Bug reports
- Installation issues
- Usage questions
- Wiki documentation issues

![image](https://github.com/user-attachments/assets/992d4ffb-710e-4e4e-a638-07c4efbf37b2)
