### PR TITLE
docs: fix separate tab typo

### DIFF
--- a/superior-agent-v1/README.md
+++ b/superior-agent-v1/README.md
@@ -212,7 +212,7 @@ docker compose up -d
 ```
 
 
-## Run the agent (in a seperate tab)
+## Run the agent (in a separate tab)
 
 To run the trading/marketing bot
 


### PR DESCRIPTION
## Summary
- fix a README heading typo: seperate -> separate

## Validation
- git diff --check

Confidence: 85% (docs/typo).